### PR TITLE
Refactor configuration files to use environment variables for sensitive data and streamline deployment settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -395,3 +395,4 @@ k8s/charts/config
 coverage-html/
 coverage.info 
 coverage.json
+.env

--- a/Deployments/helm/discount/templates/configmap.yaml
+++ b/Deployments/helm/discount/templates/configmap.yaml
@@ -10,5 +10,5 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  DatabaseSettings__ConnectionString: Server=discountdb;Port=5432;Database=DiscountDb;User Id=admin;Password=Password@1;
+  DatabaseSettings__ConnectionString: Server=discountdb;Port=5432;Database=DiscountDb;User Id=${POSTGRES_USER};Password=${DB_PASSWORD};
   ElasticConfiguration__Uri: http://elasticsearch:9200

--- a/Deployments/helm/discount/templates/configmap.yaml
+++ b/Deployments/helm/discount/templates/configmap.yaml
@@ -1,14 +1,14 @@
-{{- $name := include "discount-grpc.fullname" . -}}
+{{- $name := include "discount.fullname" . -}}
 
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "cfg-{{ $name }}"
   labels:
-    app: {{ template "discount-grpc.name" . }}
-    chart: {{ template "discount-grpc.chart" .}}
+    app: {{ template "discount.name" . }}
+    chart: {{ template "discount.chart" .}}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  DatabaseSettings__ConnectionString: Server=discountdb;Port=5432;Database=DiscountDb;User Id=${POSTGRES_USER};Password=${DB_PASSWORD};
+  DatabaseSettings__ConnectionString: Server=discountdb;Port=5432;Database=DiscountDb;User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};Pooling=true;
   ElasticConfiguration__Uri: http://elasticsearch:9200

--- a/Deployments/helm/discountdb/values.yaml
+++ b/Deployments/helm/discountdb/values.yaml
@@ -85,8 +85,8 @@ affinity: {}
 env:
   values:
     - name: POSTGRES_PASSWORD
-      value: "Password@1"
+      value: "${POSTGRES_PASSWORD}"
     - name: POSTGRES_USER
-      value: "admin"
+      value: "${POSTGRES_USER}"
     - name: POSTGRES_DB
-      value: DiscountDb  
+      value: "${POSTGRES_DB}"  

--- a/Deployments/helm/orderdb/values.yaml
+++ b/Deployments/helm/orderdb/values.yaml
@@ -5,26 +5,25 @@
 replicaCount: 1
 
 image:
-  repository: mcr.microsoft.com/mssql/server
+  repository: mcr.microsoft.com/mssql/server:2022-latest
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "2017-latest"
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""
-fullnameOverride: "orderdb"
+fullnameOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created
-  create: false
+  create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
-podAnnotations:
-  sidecar.istio.io/inject: "false"
+podAnnotations: {}
 
 podSecurityContext: {}
   # fsGroup: 2000
@@ -85,6 +84,6 @@ affinity: {}
 env:
   values:
     - name: SA_PASSWORD
-      value: "Tlvptlvp2006"
+      value: "${SQL_SA_PASSWORD}"
     - name: ACCEPT_EULA
-      value: "Y"      
+      value: "${ACCEPT_EULA}"      

--- a/Deployments/helm/ordering/templates/configmap.yaml
+++ b/Deployments/helm/ordering/templates/configmap.yaml
@@ -10,6 +10,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  ConnectionStrings__OrderingConnectionString: Server=orderdb;Database=OrderDb;User Id=sa;Password=${DB_PASSWORD};TrustServerCertificate=True
+  ConnectionStrings__OrderingConnectionString: Server=orderdb;Database=OrderDb;User Id=sa;Password=${SQL_SA_PASSWORD};TrustServerCertificate=True
   ElasticConfiguration__Uri: http://elasticsearch:9200
   EventBusSettings__HostAddress: amqp://guest:guest@rabbitmq:5672

--- a/Deployments/helm/ordering/templates/configmap.yaml
+++ b/Deployments/helm/ordering/templates/configmap.yaml
@@ -10,6 +10,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  ConnectionStrings__OrderingConnectionString: Server=orderdb;Database=OrderDb;User Id=sa;Password=Tlvptlvp2006
+  ConnectionStrings__OrderingConnectionString: Server=orderdb;Database=OrderDb;User Id=sa;Password=${DB_PASSWORD};TrustServerCertificate=True
   ElasticConfiguration__Uri: http://elasticsearch:9200
   EventBusSettings__HostAddress: amqp://guest:guest@rabbitmq:5672

--- a/Deployments/istio/kiali-secret.yaml
+++ b/Deployments/istio/kiali-secret.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app: kiali
 data:
-  username: YWRtaW4=
-  passphrase: YWRtaW4=
+  username: ${KIALI_USERNAME_BASE64}
+  passphrase: ${KIALI_PASSWORD_BASE64}

--- a/Deployments/k8s/catalog/catalog-db/mongo-configmap.yaml
+++ b/Deployments/k8s/catalog/catalog-db/mongo-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: mongo-configmap
 data:
-  connection_string: mongodb://username:password@mongo-service:27017
+  connection_string: mongodb://${MONGO_USER}:${DB_PASSWORD}@mongo-service:27017
   DatabaseName: CatalogDb
   CollectionName: Products
   BrandsCollection: Brands

--- a/Deployments/k8s/catalog/catalog-db/mongo-secret.yaml
+++ b/Deployments/k8s/catalog/catalog-db/mongo-secret.yaml
@@ -4,5 +4,5 @@ metadata:
   name: mongo-secret
 type: Opaque
 data:
-  mongo-root-username: dXNlcm5hbWU=
-  mongo-root-password: cGFzc3dvcmQ=
+  mongo-root-username: ${MONGO_USER_BASE64}
+  mongo-root-password: ${MONGO_PASSWORD_BASE64}

--- a/Services/Basket/Basket.API/appsettings.json
+++ b/Services/Basket/Basket.API/appsettings.json
@@ -1,14 +1,14 @@
 {
   "CacheSettings": {
-    "ConnectionString": "localhost:6379"
+    "ConnectionString": "${REDIS_URL}"
   },
   "GrpcSettings": {
-    "DiscountUrl": "http://localhost:8002"
+    "DiscountUrl": "http://discount.api:8080"
   },
   "EventBusSettings": {
-    "HostAddress": "amqp://guest:guest@localhost:5672"
+    "HostAddress": "${RABBITMQ_URL}"
   },
   "ElasticConfiguration": {
-    "Uri": "http://localhost:9200"
+    "Uri": "${ELASTICSEARCH_URL}"
   }
 }

--- a/Services/Catalog/Catalog.API/appsettings.json
+++ b/Services/Catalog/Catalog.API/appsettings.json
@@ -1,12 +1,12 @@
 {
   "DatabaseSettings": {
-    "ConnectionString": "mongodb://127.0.0.1:27017?readPreference=primary&ssl=false",
-    "DatabaseName": "CatalogDb",
+    "ConnectionString": "${MONGODB_URL}",
+    "DatabaseName": "${MONGO_DB}",
     "CollectionName": "Products",
     "BrandsCollection": "Brands",
     "TypesCollection": "Types"
   },
   "ElasticConfiguration": {
-    "Uri": "http://localhost:9200"
+    "Uri": "${ELASTICSEARCH_URL}"
   }
 }

--- a/Services/Discount/Discount.API/appsettings.json
+++ b/Services/Discount/Discount.API/appsettings.json
@@ -1,6 +1,6 @@
 {
 	"DatabaseSettings": {
-		"ConnectionString": "Server=localhost;Port=5432;Database=DiscountDb;User Id=slowey;Password=Tlvptlvp2006@;"
+		"ConnectionString": "${POSTGRES_URL}"
 	},
 	"AllowedHosts": "*",
 	"Kestrel": {
@@ -9,6 +9,6 @@
 		}
 	},
 	"ElasticConfiguration": {
-		"Uri": "http://localhost:9200"
+		"Uri": "${ELASTICSEARCH_URL}"
 	}
 }

--- a/Services/Ordering/Ordering.API/appsettings.json
+++ b/Services/Ordering/Ordering.API/appsettings.json
@@ -1,12 +1,12 @@
 {
 	"ConnectionStrings": {
-		"OrderingConnectionString": "Server=localhost;Database=OrderDb;User Id=sa;Password=Tlvptlvp2006@;TrustServerCertificate=True;"
+		"OrderingConnectionString": "${SQLSERVER_URL}"
 	},
 	"EventBusSettings": {
-		"HostAddress": "amqp://guest:guest@localhost:5672"
+		"HostAddress": "${RABBITMQ_URL}"
 	},
 	"ElasticConfiguration": {
-		"Uri": "http://localhost:9200"
+		"Uri": "${ELASTICSEARCH_URL}"
 	},
 	"AllowedHosts": "*"
 }

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,16 +18,16 @@ services:
   discountdb:
     container_name: discountdb
     environment:
-      - POSTGRES_USER=slowey
-      - POSTGRES_PASSWORD=Tlvptlvp2006@
-      - POSTGRES_DB=DiscountDb
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - POSTGRES_DB=${POSTGRES_DB}
     restart: always
     ports:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U slowey -d postgres" ]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d postgres" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -35,15 +35,15 @@ services:
   orderdb:
     container_name: orderdb
     environment:
-      SA_PASSWORD: "Tlvptlvp2006@"
-      ACCEPT_EULA: "Y"
+      SA_PASSWORD: ${SQL_SA_PASSWORD}
+      ACCEPT_EULA: ${ACCEPT_EULA}
     restart: always
     ports:
       - "1433:1433"
     volumes:
       - orderdb-data:/var/opt/mssql
     healthcheck:
-      test: [ "CMD-SHELL", "/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P 'Tlvptlvp2006@' -Q 'select 1'" ]
+      test: [ "CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P '${SQL_SA_PASSWORD}' -Q 'select 1' -C" ]
       interval: 10s
       timeout: 10s
       retries: 3
@@ -54,12 +54,15 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+    environment:
+      - RABBITMQ_DEFAULT_USER=${RABBITMQ_USER}
+      - RABBITMQ_DEFAULT_PASS=${RABBITMQ_PASSWORD}
 
   pgadmin:
     container_name: pgadmin
     environment:
-      - PGADMIN_DEFAULT_EMAIL=sloweycontact@gmail.com
-      - PGADMIN_DEFAULT_PASSWORD=Tlvptlvp2006@
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_EMAIL}
+      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_PASSWORD}
     restart: always
     ports:
       - "5050:80"
@@ -80,12 +83,12 @@ services:
     container_name: catalog.api
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - "DatabaseSettings__ConnectionString=mongodb://catalogdb:27017"
-      - "DatabaseSettings__DatabaseName=CatalogDb"
-      - "DatabaseSettings__CollectionName=Products"
-      - "DatabaseSettings__BrandsCollection=Brands"
-      - "DatabaseSettings__TypesCollection=Types"
-      - "ElasticConfiguration__Uri=http://elasticsearch:9200"
+      - DatabaseSettings__ConnectionString=${MONGODB_URL}
+      - DatabaseSettings__DatabaseName=${MONGO_DB}
+      - DatabaseSettings__CollectionName=Products
+      - DatabaseSettings__BrandsCollection=Brands
+      - DatabaseSettings__TypesCollection=Types
+      - ElasticConfiguration__Uri=${ELASTICSEARCH_URL}
     depends_on:
       - catalogdb
     ports:
@@ -95,10 +98,10 @@ services:
     container_name: basket.api
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - "CacheSettings__ConnectionString=basketdb:6379"
-      - "GrpcSettings__DiscountUrl=http://discount.api:8080"
-      - "EventBusSettings__HostAddress=amqp://guest:guest@rabbitmq:5672"
-      - "ElasticConfiguration__Uri=http://elasticsearch:9200"
+      - CacheSettings__ConnectionString=${REDIS_URL}
+      - GrpcSettings__DiscountUrl=http://discount.api:8080
+      - EventBusSettings__HostAddress=${RABBITMQ_URL}
+      - ElasticConfiguration__Uri=${ELASTICSEARCH_URL}
     depends_on:
       - basketdb
       - rabbitmq
@@ -109,8 +112,8 @@ services:
     container_name: discount.api
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - "DatabaseSettings__ConnectionString=Server=discountdb;Port=5432;Database=DiscountDb;User Id=slowey;Password=Tlvptlvp2006@;Pooling=true;"
-      - "ElasticConfiguration__Uri=http://elasticsearch:9200"
+      - DatabaseSettings__ConnectionString=${POSTGRES_URL}
+      - ElasticConfiguration__Uri=${ELASTICSEARCH_URL}
     depends_on:
       discountdb:
         condition: service_healthy
@@ -121,9 +124,9 @@ services:
     container_name: ordering.api
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
-      - "ConnectionStrings__OrderingConnectionString=Server=orderdb;Database=OrderDb;User Id=sa;Password=Tlvptlvp2006@;TrustServerCertificate=True"
-      - "EventBusSettings__HostAddress=amqp://guest:guest@rabbitmq:5672"
-      - "ElasticConfiguration__Uri=http://elasticsearch:9200"
+      - ConnectionStrings__OrderingConnectionString=${SQLSERVER_URL}
+      - EventBusSettings__HostAddress=${RABBITMQ_URL}
+      - ElasticConfiguration__Uri=${ELASTICSEARCH_URL}
     depends_on:
       - orderdb
       - rabbitmq
@@ -144,7 +147,7 @@ services:
   elasticsearch:
     container_name: elasticsearch
     environment:
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - ES_JAVA_OPTS=${ES_JAVA_OPTS}
       - discovery.type=single-node
       - xpack.security.enabled=false
     ports:
@@ -155,7 +158,7 @@ services:
   kibana:
     container_name: kibana
     environment:
-      - ELASTICSEARCH_URL=http://elasticsearch:9200
+      - ELASTICSEARCH_URL=${ELASTICSEARCH_URL}
     depends_on:
       - elasticsearch
     ports:


### PR DESCRIPTION
This pull request focuses on improving security and flexibility by replacing hardcoded sensitive information with environment variables across various configuration files. Additionally, it includes minor updates to image tags and service configurations.

### Environment Variable Integration for Sensitive Information:

* [`Deployments/helm/discount/templates/configmap.yaml`](diffhunk://#diff-ee9da8e5de8feae0b5191e0c7d2677e7827260579be21b50575b02323a368e13L1-R13): Replaced hardcoded PostgreSQL connection string credentials with environment variables (`POSTGRES_USER`, `POSTGRES_PASSWORD`).
* `Deployments/helm/discountdb/values.yaml` and `Deployments/helm/orderdb/values.yaml`: Updated PostgreSQL and SQL Server credentials to use environment variables (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `SQL_SA_PASSWORD`, etc.). [[1]](diffhunk://#diff-b8ce4b270d577315fe2aae33c3ba86d0c9b9604ed6652c06e417a284003edd85L88-R92) [[2]](diffhunk://#diff-4fae9dee7a95aa37dc29dc1cafd0f8cd1121bf24b02019d590c9ded0d02e08bbL88-R89)
* [`Services/*/appsettings.json`](diffhunk://#diff-f5df26068051d26d9196a647b7b557e4abb0b70d2bc98d8a53bad808ec959348L3-R12): Updated connection strings and service URLs to use environment variables (e.g., `POSTGRES_URL`, `RABBITMQ_URL`, `ELASTICSEARCH_URL`). [[1]](diffhunk://#diff-f5df26068051d26d9196a647b7b557e4abb0b70d2bc98d8a53bad808ec959348L3-R12) [[2]](diffhunk://#diff-52f759784f50d7c13bad07468a1418978e7e11331538ec643188e4bdf7136af6L3-R10) [[3]](diffhunk://#diff-b23e70c18786f6025205eef14714f595c7ada1040a8abd21f45b3657c5e322f5L3-R3) [[4]](diffhunk://#diff-9cc0ea571caee7cd4a0c406dcf321dc854fcecac2309bdf544b5383f81096465L3-R9)
* [`docker-compose.override.yml`](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58L21-R46): Replaced hardcoded environment variables for database credentials, RabbitMQ, Elasticsearch, and other services with placeholders (e.g., `${POSTGRES_USER}`, `${RABBITMQ_USER}`). [[1]](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58L21-R46) [[2]](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58R57-R65) [[3]](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58L83-R91)

### Security Enhancements:

* `Deployments/k8s/catalog/catalog-db/mongo-configmap.yaml` and `mongo-secret.yaml`: Replaced hardcoded MongoDB credentials with environment variables (`MONGO_USER`, `MONGO_PASSWORD`). [[1]](diffhunk://#diff-afbd0ade9130ed3d49ac7cc61b9049a630caab3bb21df2c91b26eced37935202L6-R6) [[2]](diffhunk://#diff-57e81567862e9def27f68594e3c576e7e670bdec0facc8dbe11a996fc27b4b65L7-R8)
* [`Deployments/istio/kiali-secret.yaml`](diffhunk://#diff-b2f347d8826df73cfb49088544a6062e0661386f74b5587c7bf8dc16e35e691bL10-R11): Updated Kiali credentials to use base64-encoded environment variables (`KIALI_USERNAME_BASE64`, `KIALI_PASSWORD_BASE64`).

### Image and Service Configuration Updates:

* [`Deployments/helm/orderdb/values.yaml`](diffhunk://#diff-4fae9dee7a95aa37dc29dc1cafd0f8cd1121bf24b02019d590c9ded0d02e08bbL8-R26): Updated SQL Server image to `2022-latest` and enabled service account creation. Removed Istio sidecar injection annotations.
* [`docker-compose.override.yml`](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58L147-R150): Adjusted Elasticsearch and Kibana configurations to use environment variables for Java options and Elasticsearch URL. [[1]](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58L147-R150) [[2]](diffhunk://#diff-2286cdeca85adb587a9640aa34352ba7c2fb6e49c0129dab05892ff67d0d4c58L158-R161)