### PR TITLE
Fix discount preservation in basket updates

### DIFF
--- a/Services/Basket/Basket.Application/Handlers/CreateShoppingCartCommandHandler.cs
+++ b/Services/Basket/Basket.Application/Handlers/CreateShoppingCartCommandHandler.cs
@@ -30,12 +30,15 @@ public class CreateShoppingCartCommandHandler : IRequestHandler<CreateShoppingCa
                 item.OriginalPrice = item.Price;
             }
 
-            // Get discount for this product
-            var coupon = await _discountGrpcService.GetDiscount(item.ProductName);
-            item.DiscountAmount = coupon.Amount;
+            // Apply discount only if it hasn't been applied yet
+            if (item.DiscountAmount == 0 && item.Price == item.OriginalPrice)
+            {
+                var coupon = await _discountGrpcService.GetDiscount(item.ProductName);
+                item.DiscountAmount = coupon.Amount;
 
-            // Update the Price to reflect the discounted price
-            item.Price = item.OriginalPrice - item.DiscountAmount;
+                // Update the Price to reflect the discounted price
+                item.Price = item.OriginalPrice - item.DiscountAmount;
+            }
         }
 
         var shoppingCart = await _basketRepository.UpdateBasket(new ShoppingCart


### PR DESCRIPTION
This pull request refines the discount application logic in the `CreateShoppingCartCommandHandler` class to ensure discounts are only applied when they haven't been previously applied. 

Key change:

* [`Services/Basket/Basket.Application/Handlers/CreateShoppingCartCommandHandler.cs`](diffhunk://#diff-2c2f7db4e2498468459ea5f669056e8ba7720f60e9aba56f80d64b97e3006761L33-R42): Updated the discount application logic to include a conditional check (`item.DiscountAmount == 0 && item.Price == item.OriginalPrice`) before applying the discount, preventing redundant discount calculations.