### PR TITLE
feat: Update deployment scripts and configurations for improved Grafana

### DIFF
--- a/Deployments/helm/portainer/templates/deployment.yaml
+++ b/Deployments/helm/portainer/templates/deployment.yaml
@@ -35,6 +35,13 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
+          env:
+            {{- if .Values.env }}
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+            {{- end }}
           volumeMounts:
             - name: portainer-data
               mountPath: /data

--- a/Deployments/helm/portainer/values.yaml
+++ b/Deployments/helm/portainer/values.yaml
@@ -41,3 +41,10 @@ persistence:
   storageClass: ""
   accessMode: ReadWriteOnce
   size: 1Gi
+
+# Environment variables for Portainer configuration
+env:
+  - name: PORTAINER_SESSION_TIMEOUT
+    value: "24h"
+  - name: PORTAINER_LOGO
+    value: "https://portainer.io/images/logos/portainer.png"

--- a/deploy.sh
+++ b/deploy.sh
@@ -127,6 +127,11 @@ deploy_infrastructure() {
     helm install eshopping-portainer ./portainer --namespace default --timeout 600s
     helm install eshopping-pgadmin ./pgadmin --namespace default --timeout 600s
 
+    # Wait for management tools to be ready
+    log_info "Waiting for management tools to be ready..."
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=portainer -n default --timeout=600s || log_warning "Portainer pod may not be ready yet"
+    kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=pgadmin -n default --timeout=600s || log_warning "pgAdmin pod may not be ready yet"
+
     cd ../..
 
     log_success "Infrastructure services deployed"
@@ -181,13 +186,25 @@ deploy_monitoring() {
     
     # Install Istio addons
     log_info "Installing Istio addons..."
-    kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/grafana.yaml
-    kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/jaeger.yaml
-    kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.20/samples/addons/kiali.yaml
+    kubectl apply -f ./istio-*/samples/addons/grafana.yaml
+    kubectl apply -f ./istio-*/samples/addons/jaeger.yaml
+    kubectl apply -f ./istio-*/samples/addons/kiali.yaml
 
     # Wait for Grafana pod to be ready
     log_info "Waiting for Grafana to be ready..."
     kubectl wait --for=condition=ready pod -l app=grafana -n istio-system --timeout=600s || log_warning "Grafana pod may not be ready yet, but continuing deployment"
+
+    # Wait for Kiali pod to be ready
+    log_info "Waiting for Kiali to be ready..."
+    kubectl wait --for=condition=ready pod -l app=kiali -n istio-system --timeout=600s || log_warning "Kiali pod may not be ready yet, but continuing deployment"
+
+    # Fix Kiali-Prometheus connection
+    log_info "Applying Kiali-Prometheus connection fix..."
+    if [ -f "scripts/monitoring/fix-kiali-prometheus-connection.sh" ]; then
+        ./scripts/monitoring/fix-kiali-prometheus-connection.sh
+    else
+        log_warning "Kiali fix script not found, Kiali may have connectivity issues"
+    fi
 
     # Apply permanent Grafana fix
     log_info "Applying Grafana configuration..."

--- a/scripts/monitoring/fix-kiali-prometheus-connection.sh
+++ b/scripts/monitoring/fix-kiali-prometheus-connection.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Script to fix Kiali-Prometheus connection
+# This ensures Kiali can connect to Prometheus in the monitoring namespace
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+echo "🔧 Fixing Kiali-Prometheus Connection..."
+
+# Check if Kiali is deployed
+if ! kubectl get deployment kiali -n istio-system > /dev/null 2>&1; then
+    log_error "Kiali deployment not found in istio-system namespace"
+    exit 1
+fi
+
+# Check if Prometheus is accessible
+log_info "Checking Prometheus connectivity..."
+if ! kubectl run test-prometheus-connectivity --image=curlimages/curl --rm -i --restart=Never -- curl -s --max-time 10 "http://prometheus-server.monitoring.svc.cluster.local:80/api/v1/query?query=up" > /dev/null 2>&1; then
+    log_error "Prometheus is not accessible at prometheus-server.monitoring.svc.cluster.local:80"
+    exit 1
+fi
+log_success "Prometheus is accessible"
+
+# Update Kiali configuration
+log_info "Updating Kiali configuration..."
+kubectl patch configmap kiali -n istio-system --type merge -p '{
+  "data": {
+    "config.yaml": "auth:\n  openid: {}\n  openshift:\n    client_id_prefix: kiali\n  strategy: anonymous\ndeployment:\n  accessible_namespaces:\n  - \"**\"\n  additional_service_yaml: {}\n  affinity:\n    node: {}\n    pod: {}\n    pod_anti: {}\n  configmap_annotations: {}\n  custom_secrets: []\n  host_aliases: []\n  hpa:\n    api_version: autoscaling/v2beta2\n    spec: {}\n  image_digest: \"\"\n  image_name: quay.io/kiali/kiali\n  image_pull_policy: Always\n  image_pull_secrets: []\n  image_version: v1.76\n  ingress:\n    additional_labels: {}\n    class_name: nginx\n    override_yaml:\n      metadata: {}\n  ingress_enabled: false\n  instance_name: kiali\n  logger:\n    log_format: text\n    log_level: info\n    sampler_rate: \"1\"\n    time_field_format: 2006-01-02T15:04:05Z07:00\n  namespace: istio-system\n  node_selector: {}\n  pod_annotations: {}\n  pod_labels:\n    sidecar.istio.io/inject: \"false\"\n  priority_class_name: \"\"\n  replicas: 1\n  resources:\n    limits:\n      memory: 1Gi\n    requests:\n      cpu: 10m\n      memory: 64Mi\n  secret_name: kiali\n  security_context: {}\n  service_annotations: {}\n  service_type: \"\"\n  tolerations: []\n  version_label: v1.76.0\n  view_only_mode: false\nexternal_services:\n  custom_dashboards:\n    enabled: true\n  istio:\n    root_namespace: istio-system\n  prometheus:\n    url: \"http://prometheus-server.monitoring.svc.cluster.local:80\"\nidentity:\n  cert_file: \"\"\n  private_key_file: \"\"\nistio_namespace: istio-system\nkiali_feature_flags:\n  certificates_information_indicators:\n    enabled: true\n    secrets:\n    - cacerts\n    - istio-ca-secret\n  clustering:\n    autodetect_secrets:\n      enabled: true\n      label: kiali.io/multiCluster=true\n    clusters: []\n  disabled_features: []\n  validations:\n    ignore:\n    - KIA1301\nlogin_token:\n  signing_key: CHANGEME00000000\nserver:\n  metrics_enabled: true\n  metrics_port: 9090\n  port: 20001\n  web_root: /kiali\n"
+  }
+}'
+
+log_success "Kiali configuration updated"
+
+# Restart Kiali deployment
+log_info "Restarting Kiali deployment..."
+kubectl rollout restart deployment/kiali -n istio-system
+
+# Wait for rollout to complete
+log_info "Waiting for Kiali to restart..."
+kubectl rollout status deployment/kiali -n istio-system --timeout=300s
+
+log_success "Kiali-Prometheus connection fix applied successfully!"
+
+# Verify the fix
+log_info "Verifying Kiali can connect to Prometheus..."
+sleep 10
+
+# Check Kiali logs for errors
+if kubectl logs -n istio-system deployment/kiali --tail=20 | grep -q "Failed to fetch Prometheus"; then
+    log_warning "Kiali may still have issues connecting to Prometheus. Check logs manually."
+else
+    log_success "No Prometheus connection errors found in Kiali logs"
+fi
+
+echo ""
+echo "✅ Kiali-Prometheus connection fix completed!"
+echo "🌐 Access Kiali at: http://localhost:20001/kiali"
+echo "💡 If you still see initialization errors, wait a few minutes and refresh the browser."

--- a/scripts/monitoring/fix-portainer-timeout.sh
+++ b/scripts/monitoring/fix-portainer-timeout.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Script to fix Portainer timeout issues and apply permanent configuration
+# This ensures Portainer has longer session timeout and better persistence
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+echo "🔧 Applying Permanent Portainer Timeout Fix..."
+
+# Check if Portainer is deployed
+if ! kubectl get deployment portainer -n default > /dev/null 2>&1; then
+    log_error "Portainer deployment not found in default namespace"
+    exit 1
+fi
+
+# Check current Portainer status
+log_info "Checking current Portainer status..."
+PORTAINER_STATUS=$(kubectl get pods -l app.kubernetes.io/name=portainer -n default -o jsonpath='{.items[0].status.phase}' 2>/dev/null || echo "NotFound")
+
+if [ "$PORTAINER_STATUS" != "Running" ]; then
+    log_warning "Portainer pod is not running. Current status: $PORTAINER_STATUS"
+fi
+
+# Upgrade Portainer with new configuration
+log_info "Upgrading Portainer with extended timeout configuration..."
+cd Deployments/helm
+helm upgrade eshopping-portainer ./portainer --namespace default --timeout 600s
+
+# Wait for rollout to complete
+log_info "Waiting for Portainer to restart with new configuration..."
+kubectl rollout status deployment/portainer -n default --timeout=300s
+
+# Verify the deployment
+log_info "Verifying Portainer deployment..."
+kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=portainer -n default --timeout=300s
+
+log_success "Portainer has been restarted with extended timeout configuration"
+
+# Check if port forward is running
+log_info "Checking port forward status..."
+if ! pgrep -f "kubectl.*port-forward.*portainer.*9000" > /dev/null; then
+    log_info "Starting Portainer port forward..."
+    kubectl port-forward svc/portainer 9000:9000 -n default > /dev/null 2>&1 &
+    sleep 3
+fi
+
+# Test connectivity
+log_info "Testing Portainer connectivity..."
+if curl -s -o /dev/null -w "%{http_code}" http://localhost:9000 | grep -q "200"; then
+    log_success "Portainer is accessible at http://localhost:9000"
+else
+    log_warning "Portainer may not be fully ready yet. Please wait a moment and try again."
+fi
+
+cd ../..
+
+echo ""
+echo "✅ Portainer timeout fix completed!"
+echo ""
+echo "📋 Configuration Applied:"
+echo "   • Session Timeout: 24 hours (instead of default 8 hours)"
+echo "   • Persistent Data: Enabled with 1Gi storage"
+echo "   • Auto-restart: Configured"
+echo ""
+echo "🌐 Access Portainer:"
+echo "   URL: http://localhost:9000"
+echo "   First-time setup: Create admin user when prompted"
+echo ""
+echo "💡 Tips:"
+echo "   • The timeout issue should no longer occur"
+echo "   • Your Portainer data will persist across restarts"
+echo "   • If you see the timeout message again, just refresh the browser"


### PR DESCRIPTION
This pull request introduces several improvements to the Helm deployment configuration and deployment scripts, focusing on better environment variable management, enhanced readiness checks, and fixes for connectivity and timeout issues in Portainer and Kiali. The most important changes are grouped below by theme.

### Helm Deployment Enhancements:
* Added support for environment variables in the Portainer Helm chart by introducing a new `env` section in `values.yaml` and updating `deployment.yaml` to dynamically inject these variables. Example variables include `PORTAINER_SESSION_TIMEOUT` and `PORTAINER_LOGO`. [[1]](diffhunk://#diff-bfe25fd181c8a6436234ece6938d29de165d179c8c4f70618bfae7d06a1c9524R38-R44) [[2]](diffhunk://#diff-1cad54335291159535d5d7001365a6102c625d66f41c3329b4325c63fa96be65R44-R50)

### Deployment Script Improvements:
* Added readiness checks for Portainer and pgAdmin pods in `deploy_infrastructure()` to ensure they are ready before proceeding.
* Updated `deploy_monitoring()` to use local Istio addon YAML files instead of remote URLs and added readiness checks for Kiali. Introduced a fix for Kiali-Prometheus connectivity using a new script.

### New Fix Scripts:
* Introduced `fix-kiali-prometheus-connection.sh` to ensure Kiali can connect to Prometheus, including configuration updates and deployment restarts.
* Added `fix-portainer-timeout.sh` to address Portainer timeout issues, applying extended session timeout and ensuring persistent data storage.