### PR TITLE
fix: Increase Kibana readiness probe tolerance for CI stability

### DIFF
--- a/Deployments/k8s/infrastructure/kibana.yaml
+++ b/Deployments/k8s/infrastructure/kibana.yaml
@@ -53,9 +53,10 @@ spec:
             httpGet:
               path: /api/status
               port: 5601
-            initialDelaySeconds: 90
+            initialDelaySeconds: 120
             periodSeconds: 15
             timeoutSeconds: 10
+            failureThreshold: 10
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
- Increase initialDelaySeconds from 90s to 120s
- Add failureThreshold: 10 to tolerate 503 responses during initialization
- Kibana needs extra time to connect to Elasticsearch and initialize
