### PR TITLE
chore: align all services on MassTransit 8.x

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,11 +48,10 @@
     <!-- gRPC -->
     <PackageVersion Include="Grpc.AspNetCore" Version="2.64.0" />
 
-    <!-- Messaging. MassTransit 7.x is EOL (Basket/Ordering still pinned via
-         VersionOverride pending migration to 8.x). -->
+    <!-- Messaging. All services on 8.x stable line (free/OSS).
+         MassTransit.AspNetCore is gone in 8.x — features absorbed into core. -->
     <PackageVersion Include="MassTransit" Version="8.1.3" />
     <PackageVersion Include="MassTransit.RabbitMQ" Version="8.1.3" />
-    <PackageVersion Include="MassTransit.AspNetCore" Version="7.3.1" />
 
     <!-- Mediator. MediatR 13+ is commercially licensed (Jimmy Bogard, 2024).
          12.x is the last free version. Tracked for migration. -->

--- a/Services/Basket/Basket.API/Basket.API.csproj
+++ b/Services/Basket/Basket.API/Basket.API.csproj
@@ -13,9 +13,8 @@
 		<PackageReference Include="Asp.Versioning.Mvc" />
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" />
 		<PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
-		<PackageReference Include="MassTransit" VersionOverride="7.3.1" />
-		<PackageReference Include="MassTransit.AspNetCore" />
-		<PackageReference Include="MassTransit.RabbitMQ" VersionOverride="7.3.1" />
+		<PackageReference Include="MassTransit" />
+		<PackageReference Include="MassTransit.RabbitMQ" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
 		<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />

--- a/Services/Basket/Basket.API/Program.cs
+++ b/Services/Basket/Basket.API/Program.cs
@@ -125,7 +125,6 @@ builder.Services.AddMassTransit(config =>
         });
     });
 });
-builder.Services.AddMassTransitHostedService();
 
 var app = builder.Build();
 

--- a/Services/Catalog/Catalog.API/Program.cs
+++ b/Services/Catalog/Catalog.API/Program.cs
@@ -146,7 +146,6 @@ builder.Services.AddMassTransit(config =>
         cfg.Host(builder.Configuration["EventBusSettings:HostAddress"]);
     });
 });
-builder.Services.AddMassTransitHostedService();
 
 var app = builder.Build();
 

--- a/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -15,9 +15,8 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="MassTransit" VersionOverride="7.3.1" />
-		<PackageReference Include="MassTransit.AspNetCore" />
-		<PackageReference Include="MassTransit.RabbitMQ" VersionOverride="7.3.1" />
+		<PackageReference Include="MassTransit" />
+		<PackageReference Include="MassTransit.RabbitMQ" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" />
 		<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/Services/Ordering/Ordering.API/Program.cs
+++ b/Services/Ordering/Ordering.API/Program.cs
@@ -90,7 +90,6 @@ builder.Services.AddMassTransit(config =>
             c => { c.ConfigureConsumer<OrderActivityConsumer>(ctx); });
     });
 });
-builder.Services.AddMassTransitHostedService();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary

Stacked on top of #318. Removes the `VersionOverride="7.3.1"` introduced there and brings Basket.API + Ordering.API up to MassTransit 8.1.3, matching Catalog.API. MassTransit 7.x has been EOL for years.

## Changes

- Drop `VersionOverride="7.3.1"` from MassTransit and MassTransit.RabbitMQ in Basket.API and Ordering.API csproj
- Remove `MassTransit.AspNetCore` package reference — does not exist in 8.x (folded into the core package)
- Drop `MassTransit.AspNetCore` from `Directory.Packages.props`
- Remove vestigial `AddMassTransitHostedService()` calls in 3 Program.cs files (8.x registers the hosted service automatically)

No producer code changes — `IPublishEndpoint` is unchanged across 7 → 8.

## Test plan

- [x] `dotnet build Ecommerce.sln` — 0 errors
- [ ] CI: docker builds for basket-api and ordering-api pass
- [ ] CI: integration smoke tests pass

## Stack

1. #318 — CPM + audit doc (base for this PR)
2. **this PR** — MassTransit 7 → 8
3. Coming: .NET 10 LTS bump
4. Coming: AutoMapper → Mapperly (removes HIGH CVE)
5. Coming: MediatR → in-process dispatcher
6. Coming: misc version drift (OpenTelemetry CVE, MongoDB 2→3, etc.)