### PR TITLE
chore: bump target framework to .NET 10 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOTNET_VERSION: "8.0.x"
+  DOTNET_VERSION: "10.0.x"
   NODE_VERSION: "20.19.0"
   DOCKER_BUILDKIT: 1
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -59,7 +59,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -152,7 +152,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
       
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Install K6
         run: |

--- a/.github/workflows/sbom-and-license.yml
+++ b/.github/workflows/sbom-and-license.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/ApiGateways/Ocelot.ApiGateway/Dockerfile
+++ b/ApiGateways/Ocelot.ApiGateway/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Directory.Packages.props", "./"]

--- a/ApiGateways/Ocelot.ApiGateway/Ocelot.ApiGateway.csproj
+++ b/ApiGateways/Ocelot.ApiGateway/Ocelot.ApiGateway.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/Infrastructure/Common.Logging/Common.Logging.csproj
+++ b/Infrastructure/Common.Logging/Common.Logging.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Infrastructure/EventBus.Messages/EventBus.Messages.csproj
+++ b/Infrastructure/EventBus.Messages/EventBus.Messages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cloud-Native E-Commerce Platform
 
-[![.NET 8](https://img.shields.io/badge/.NET-8.0-blue.svg)](https://dotnet.microsoft.com/)
+[![.NET 10](https://img.shields.io/badge/.NET-10.0-blue.svg)](https://dotnet.microsoft.com/)
 [![React 18](https://img.shields.io/badge/React-18-61dafb.svg)](https://react.dev/)
 [![Nx](https://img.shields.io/badge/Nx-21-96267f.svg)](https://nx.dev/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178c6.svg)](https://www.typescriptlang.org/)
@@ -341,8 +341,8 @@ For detailed deployment instructions, see [DEPLOYMENT-GUIDE.md](DEPLOYMENT-GUIDE
 
 | Component | Technology | Version | Purpose |
 | --- | --- | --- | --- |
-| **Runtime** | .NET | 8.0 | Framework |
-| **Framework** | ASP.NET Core | 8.0 | Web API |
+| **Runtime** | .NET | 10.0 | Framework |
+| **Framework** | ASP.NET Core | 10.0 | Web API |
 | **Architecture** | Clean Architecture | - | SOLID principles |
 | **Pattern** | CQRS + MediatR | 12.5 | Command/Query separation |
 | **ORM** | Entity Framework Core | 8.0 | Database abstraction |
@@ -414,7 +414,7 @@ cloud-native-ecommerce-platform/
 │   ├── tsconfig.base.json                # TypeScript base config
 │   └── package.json                      # Dependencies
 │
-├── 📁 Services/                          # Backend microservices (.NET 8)
+├── 📁 Services/                          # Backend microservices (.NET 10)
 │   ├── Catalog/
 │   │   ├── Catalog.API/                  # REST endpoints
 │   │   ├── Catalog.Core/                 # Domain entities
@@ -699,7 +699,7 @@ Triggered on: Pull requests, pushes to main
 **Steps**:
 
 1. **Code Quality**
-   - Build .NET 8 backend
+   - Build .NET 10 backend
    - Run backend unit tests (with Cobertura coverage)
    - Run frontend tests via Nx affected
    - ESLint and Prettier

--- a/Services/Basket/Basket.API/Basket.API.csproj
+++ b/Services/Basket/Basket.API/Basket.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/Services/Basket/Basket.API/Dockerfile
+++ b/Services/Basket/Basket.API/Dockerfile
@@ -1,13 +1,13 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 ENV ASPNETCORE_URLS=http://+:80
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Directory.Packages.props", "./"]

--- a/Services/Basket/Basket.Application/Basket.Application.csproj
+++ b/Services/Basket/Basket.Application/Basket.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Basket/Basket.Core/Basket.Core.csproj
+++ b/Services/Basket/Basket.Core/Basket.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Basket/Basket.Infrastructure/Basket.Infrastructure.csproj
+++ b/Services/Basket/Basket.Infrastructure/Basket.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Catalog/Catalog.API/Catalog.API.csproj
+++ b/Services/Catalog/Catalog.API/Catalog.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/Services/Catalog/Catalog.API/Dockerfile
+++ b/Services/Catalog/Catalog.API/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Directory.Packages.props", "./"]

--- a/Services/Catalog/Catalog.Application/Catalog.Application.csproj
+++ b/Services/Catalog/Catalog.Application/Catalog.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Catalog/Catalog.Core/Catalog.Core.csproj
+++ b/Services/Catalog/Catalog.Core/Catalog.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Catalog/Catalog.Infrastructure/Catalog.Infrastructure.csproj
+++ b/Services/Catalog/Catalog.Infrastructure/Catalog.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Discount/Discount.API/Discount.API.csproj
+++ b/Services/Discount/Discount.API/Discount.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/Services/Discount/Discount.API/Dockerfile
+++ b/Services/Discount/Discount.API/Dockerfile
@@ -1,12 +1,12 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Directory.Packages.props", "./"]

--- a/Services/Discount/Discount.Application/Discount.Application.csproj
+++ b/Services/Discount/Discount.Application/Discount.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Discount/Discount.Core/Discount.Core.csproj
+++ b/Services/Discount/Discount.Core/Discount.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Discount/Discount.Infrastructure/Discount.Infrastructure.csproj
+++ b/Services/Discount/Discount.Infrastructure/Discount.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Ordering/Ordering.API/Dockerfile
+++ b/Services/Ordering/Ordering.API/Dockerfile
@@ -1,12 +1,12 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER app
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["Directory.Packages.props", "./"]

--- a/Services/Ordering/Ordering.API/Ordering.API.csproj
+++ b/Services/Ordering/Ordering.API/Ordering.API.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/Services/Ordering/Ordering.Application/Ordering.Application.csproj
+++ b/Services/Ordering/Ordering.Application/Ordering.Application.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Ordering/Ordering.Core/Ordering.Core.csproj
+++ b/Services/Ordering/Ordering.Core/Ordering.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
+++ b/Services/Ordering/Ordering.Infrastructure/Ordering.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/diagrams/aws-cloud-deployment.eraserdiagram
+++ b/diagrams/aws-cloud-deployment.eraserdiagram
@@ -126,7 +126,7 @@ Security Groups > EKS Cluster : Policies
 // • CI/CD: GitHub Actions → ECR → EKS (Helm)
 //
 // Services:
-// • 4 Microservices: Catalog, Basket, Discount, Ordering (ASP.NET 8.0)
+// • 4 Microservices: Catalog, Basket, Discount, Ordering (ASP.NET 10.0)
 // • API Gateway: Ocelot (routing, rate limiting)
 // • Service Mesh: Istio 1.28.2 (mTLS, traffic management)
 //

--- a/docs/MODERNIZATION-2026.md
+++ b/docs/MODERNIZATION-2026.md
@@ -11,15 +11,15 @@ A consolidated dependency audit and migration roadmap for the .NET stack. This d
 - **AutoMapper 13.0.1** has a known HIGH-severity vulnerability (GHSA-rvv3-g6hj-g44x). The free version will not be patched.
 - **MassTransit 7.x** has been EOL for years; Basket.API and Ordering.API are still on 7.3.1.
 
-## Current state (post PR 1)
+## Current state (post PR 3)
 
 | Dimension | State |
 | --- | --- |
-| Target framework | net8.0 across 19 projects |
+| Target framework | net10.0 (LTS until 2028-11) |
 | Central Package Management | ✅ enabled (`Directory.Packages.props`) |
 | Transitive pinning | ✅ enabled |
-| Build/restore | ✅ clean |
-| Known CVEs | AutoMapper 13.0.1 (high), OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.0 (3 moderate) |
+| Build/restore | ✅ clean on .NET 10 SDK 10.0.300 |
+| Known CVEs (post PR 4) | OpenTelemetry.* 1.15.0 (3 moderate), MongoDB.Driver 2.30.0 transitive Snappier 1.0.0 (HIGH), SharpCompress 0.30.1 (moderate) |
 
 ## Migration roadmap
 


### PR DESCRIPTION
## Summary

Stacked on top of #318. Moves the entire backend from .NET 8 → .NET 10 LTS.

## Why

- **.NET 9 STS** already EOL'd (**2026-05-12** — last week).
- **.NET 8 LTS** ends **2026-11-14** (~6 months from now).
- **.NET 10 LTS** released 2025-11, supported through **2028-11**.

Skipping .NET 9 entirely because it's already dead. Going straight to the next LTS.

## Scope of this PR

Strictly the framework move — minimal surface area, large impact.

- `<TargetFramework>` `net8.0` → `net10.0` across **17 csproj files**
- Dockerfile base images: `aspnet:8.0` / `sdk:8.0` → `10.0` across **5 service Dockerfiles**
- CI workflow `dotnet-version`: `8.0.x` → `10.0.x` across **5 workflows** (`ci`, `dependencies`, `dependency-update`, `performance-test`, `sbom-and-license`)
- README badge + architecture table + diagram + MODERNIZATION-2026.md updated

## Out of scope (PR 6)

Microsoft.* package versions (8.0.x line) are left unchanged here. .NET 10 is forward-compatible with .NET 8 reference assemblies via TFM downlevel, so the build is clean. Bumping `Microsoft.EntityFrameworkCore.*`, `Microsoft.Extensions.*`, etc. to their 10.x lines goes in PR 6 along with OpenTelemetry CVE fix, MongoDB.Driver 2→3, Newtonsoft removal, etc.

## New CVEs surfaced by restore on .NET 10

- `MongoDB.Driver 2.30.0` → transitive `Snappier 1.0.0` (HIGH, [GHSA-pggp-6c3x-2xmx](https://github.com/advisories/GHSA-pggp-6c3x-2xmx))
- `MongoDB.Driver 2.30.0` → transitive `SharpCompress 0.30.1` (moderate, [GHSA-6c8g-7p36-r338](https://github.com/advisories/GHSA-6c8g-7p36-r338))
- `OpenTelemetry.Api 1.15.0` (moderate, [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j))

All three are fixed by bumps planned in PR 6.

## Verification

- [x] `.NET SDK 10.0.300` installed locally
- [x] `dotnet build Ecommerce.sln` — 0 errors
- [ ] CI: container builds and integration smoke pass on .NET 10 SDK runner

## Stack

1. #318 — CPM + audit doc + MassTransit 8 + Mapperly migration (now contains 3 changes in single PR after merge)
2. **this PR** — .NET 10 LTS bump
3. Coming: MediatR → in-process dispatcher
4. Coming: OpenTelemetry CVE + MongoDB 2→3 + Newtonsoft removal + Microsoft.* 10.x + AWSSDK 4.x cleanup