### PR TITLE
chore: fix all known CVEs + bump packages to .NET 10 alignment

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     packages without a Version attribute. To override for a single project, use
     <PackageReference Include="X" VersionOverride="..." /> in that csproj.
 
-    Version drift remediation roadmap: see MODERNIZATION-2026.md.
+    Version drift remediation roadmap: see docs/MODERNIZATION-2026.md.
   -->
 
   <PropertyGroup>
@@ -18,37 +18,39 @@
 
   <ItemGroup>
     <!-- API versioning -->
-    <PackageVersion Include="Asp.Versioning.Mvc" Version="8.1.1" />
-    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.1" />
+    <PackageVersion Include="Asp.Versioning.Mvc" Version="10.0.0" />
+    <PackageVersion Include="Asp.Versioning.Mvc.ApiExplorer" Version="10.0.0" />
 
     <!-- Health checks -->
-    <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="8.0.1" />
-    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
+    <PackageVersion Include="AspNetCore.HealthChecks.MongoDb" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
 
-    <!-- AWS -->
+    <!-- AWS. AWSSDK 4.x is current; 3.7.x retained pending the 4.x migration PR. -->
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400.1" />
     <PackageVersion Include="AWSSDK.S3" Version="3.7.511.4" />
 
-    <!-- Mapping. Replaced AutoMapper with Mapperly:
-         - AutoMapper 14+ went commercial in 2024
-         - AutoMapper 13.0.1 has CVE-2026-32933 (HIGH, unpatched in free line)
-         Mapperly is MIT, source-generated, and has no runtime reflection. -->
+    <!-- Mapping. Replaced AutoMapper with Mapperly (MIT, source-gen, no reflection). -->
     <PackageVersion Include="Riok.Mapperly" Version="4.1.1" />
 
-    <!-- Data access -->
+    <!-- Data access. MongoDB.Driver 3.x fixes HIGH CVE in transitive Snappier
+         1.0.0 (GHSA-pggp-6c3x-2xmx) and moderate CVE in transitive SharpCompress
+         (GHSA-6c8g-7p36-r338). -->
     <PackageVersion Include="Dapper" Version="2.1.66" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.25" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.25" />
-    <PackageVersion Include="MongoDB.Driver" Version="2.30.0" />
-    <PackageVersion Include="Npgsql" Version="8.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.8" />
+    <PackageVersion Include="MongoDB.Driver" Version="3.8.1" />
+    <!-- Pin SharpCompress to override transitive 0.30.1 from older deps
+         (GHSA-6c8g-7p36-r338, moderate). -->
+    <PackageVersion Include="SharpCompress" Version="0.48.1" />
+    <PackageVersion Include="Npgsql" Version="10.0.0" />
 
     <!-- Validation -->
     <PackageVersion Include="FluentValidation" Version="11.12.0" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.12.0" />
 
     <!-- gRPC -->
-    <PackageVersion Include="Grpc.AspNetCore" Version="2.64.0" />
+    <PackageVersion Include="Grpc.AspNetCore" Version="2.80.0" />
 
     <!-- Messaging. All services on 8.x stable line (free/OSS).
          MassTransit.AspNetCore is gone in 8.x — features absorbed into core. -->
@@ -59,41 +61,43 @@
          12.x is the last free version. Tracked for migration. -->
     <PackageVersion Include="MediatR" Version="12.5.0" />
 
-    <!-- ASP.NET Core / Microsoft.Extensions -->
-    <PackageVersion Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.22" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <!-- ASP.NET Core / Microsoft.Extensions. Aligned with .NET 10 LTS. -->
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
 
     <!-- Tooling -->
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
 
-    <!-- Serialization -->
+    <!-- Serialization. Newtonsoft.Json retained pending System.Text.Json migration. -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
 
-    <!-- API gateway -->
+    <!-- API gateway. Ocelot 24.x retained pending the 23 → 24 migration PR. -->
     <PackageVersion Include="Ocelot" Version="23.4.3" />
 
-    <!-- Observability -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
+    <!-- Observability. 1.15.3 fixes 3 moderate CVEs reported against 1.15.0:
+         GHSA-4625-4j76-fww9, GHSA-mr8r-92fq-pj8p, GHSA-q834-8qmm-v933. -->
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.14.0-beta.1" />
 
     <!-- Resilience -->
-    <PackageVersion Include="Polly" Version="8.4.1" />
+    <PackageVersion Include="Polly" Version="8.6.6" />
 
-    <!-- Logging -->
+    <!-- Logging. Serilog.AspNetCore 10.x retained pending a dedicated bump
+         (configuration API differences). -->
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.Elasticsearch" Version="9.0.0" />
 
-    <!-- OpenAPI -->
+    <!-- OpenAPI. Swashbuckle 10.x retained pending Microsoft.AspNetCore.OpenApi
+         migration (now the in-box option since .NET 9). -->
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 

--- a/Services/Catalog/Catalog.Application/Catalog.Application.csproj
+++ b/Services/Catalog/Catalog.Application/Catalog.Application.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\Catalog.Core\Catalog.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="MediatR" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Features" />
     <PackageReference Include="Riok.Mapperly">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Eliminates every NU190x CVE warning reported by `dotnet restore` and brings Microsoft.* + ecosystem packages in line with the .NET 10 LTS target. Stacked on top of #318.

## CVE fixes (the headline)

| CVE | Where | Severity | Fix |
|---|---|---|---|
| [GHSA-pggp-6c3x-2xmx](https://github.com/advisories/GHSA-pggp-6c3x-2xmx) | Snappier 1.0.0 (transitive via MongoDB.Driver 2.30.0) | **HIGH** | MongoDB.Driver 2.30.0 → 3.8.1 |
| [GHSA-6c8g-7p36-r338](https://github.com/advisories/GHSA-6c8g-7p36-r338) | SharpCompress 0.30.1 (transitive) | Moderate | Pinned to 0.48.1 in CPM |
| [GHSA-4625-4j76-fww9](https://github.com/advisories/GHSA-4625-4j76-fww9) | OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.0 | Moderate | → 1.15.3 |
| [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p) | OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.0 | Moderate | → 1.15.3 |
| [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) | OpenTelemetry.Exporter.OpenTelemetryProtocol 1.15.0 | Moderate | → 1.15.3 |

## Microsoft.* aligned to .NET 10 LTS

- EntityFrameworkCore.{Design, SqlServer, Tools} 8.0.x → **10.0.8**
- Extensions.{Caching.StackExchangeRedis, Configuration.*, DependencyInjection, Hosting.Abstractions, Logging.Abstractions} 8.0.x → **10.0.8**
- Asp.Versioning.Mvc{, .ApiExplorer} 8.1.1 → **10.0.0**

## Ecosystem patch bumps

- Grpc.AspNetCore 2.64.0 → 2.80.0
- Polly 8.4.1 → 8.6.6
- AspNetCore.HealthChecks.* 8.0.1 → 9.0.0 (latest stable)
- Npgsql 8.0.9 → 10.0.0

## Code change

`Microsoft.AspNetCore.Http.Features 5.0.17` (a .NET 5 holdover) was removed from `Catalog.Application` and replaced with `<FrameworkReference Include="Microsoft.AspNetCore.App" />` — the modern way to access ASP.NET Core types (here `IFormFile`) from a library project.

## Out of scope (deferred to dedicated PRs)

- Ocelot 23.4.3 → 24.x — API gateway breaking changes
- Swashbuckle 6.4.0 → `Microsoft.AspNetCore.OpenApi` (now in-box since .NET 9)
- Serilog.AspNetCore 8.0.1 → 10.0 — configuration API differences
- AWSSDK 3.7.x → 4.x
- Newtonsoft.Json removal in favor of System.Text.Json

## Verification

- [x] `dotnet build Ecommerce.sln` — 0 errors
- [x] `dotnet restore Ecommerce.sln` — 0 NU190x CVE warnings
- [ ] CI: docker builds + integration smoke pass on .NET 10