### PR TITLE
fix: drop linux/arm64 from docker-build matrix (unblock PR #318 CI)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,7 +80,11 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          # arm64 dropped: Grpc.Tools/protoc segfaults under QEMU emulation in
+          # the Discount.Application build. Re-enable by refactoring the
+          # Dockerfiles to cross-compile (FROM --platform=$BUILDPLATFORM +
+          # dotnet publish -r linux-$TARGETARCH) — keeps Grpc.Tools native.
+          platforms: linux/amd64
 
       - name: Check if images were pushed
         id: push-check


### PR DESCRIPTION
## Why

The `build-and-push` matrix on PR #318 fails with:

```
qemu : error : uncaught target signal 11 (Segmentation fault) - core dumped
  [/src/Services/Discount/Discount.Application/Discount.Application.csproj]
```

QEMU-emulating linux/arm64 on x86 runners segfaults inside Grpc.Tools' protoc step. The regression surfaced after the .NET 10 bump + Grpc.AspNetCore 2.64.0 → 2.80.0 in this modernization stack (.NET 8 + older Grpc were fine).

## Fix

`docker.yml` build matrix: `linux/amd64,linux/arm64` → `linux/amd64`. cd.yml was already amd64-only.

## Re-enabling arm64 later

Refactor each service Dockerfile to use `FROM --platform=$BUILDPLATFORM` for the SDK stage and `dotnet publish -r linux-$TARGETARCH`. Grpc.Tools then runs natively on the build host (x86) and the output binary is cross-targeted at arm64. No QEMU in the build path.

Out of scope for this hotfix — its own dedicated PR if/when arm64 deploys are actually needed.
EOF
)