### PR TITLE
ci: auto-merge dependabot patch and minor bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,44 @@
+name: Dependabot auto-merge
+
+# Auto-approves and enables auto-merge for dependabot PRs that bump
+# packages by patch or minor. Major bumps are surfaced for manual review
+# (dependabot.yml also already ignores semver-major for nuget/npm; this
+# workflow is the runtime safety net for docker / github-actions
+# ecosystems where major bumps still flow through).
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-approve patch / minor bumps
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL" --body "Auto-approved by workflow — ${{ steps.meta.outputs.update-type }} bump of ${{ steps.meta.outputs.dependency-names }}."
+
+      - name: Enable GitHub auto-merge (squash) for patch / minor bumps
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Comment on major bumps (manual review required)
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment "$PR_URL" --body "🛑 Major version bump — not auto-merged. Review the changelog before approving."


### PR DESCRIPTION
## Summary

Sets up automatic merging of dependabot PRs for **patch** and **minor** bumps. Major bumps stay manual.

## What changes

- New workflow `.github/workflows/dependabot-auto-merge.yml`:
  - Fires on dependabot `pull_request_target` events
  - Uses `dependabot/fetch-metadata@v2` to inspect the bump
  - For patch/minor: auto-approves + enables GitHub auto-merge (squash)
  - For major: posts a 'manual review required' comment

## Repo settings (already enabled out-of-band)

```bash
gh api -X PATCH repos/sloweyyy/cloud-native-ecommerce-platform \
  -f allow_auto_merge=true \
  -f delete_branch_on_merge=true
```

## Why a workflow at all (vs. enabling auto-merge by hand on each PR)

`main`'s branch protection requires 1 approval. Dependabot's own
identity doesn't count (same actor as PR author). The `GITHUB_TOKEN`
inside this workflow acts as `github-actions`, which is a different
identity and satisfies the rule, so the auto-merge actually fires
once required status checks turn green.

## Defense-in-depth on major bumps

`dependabot.yml` already ignores `version-update:semver-major` for
**nuget** and **npm** ecosystems. **docker** and **github-actions**
ecosystems don't have that filter (which is why you've seen PRs like
`Bump aws-actions/configure-aws-credentials from 4 to 6` lately).
The workflow handles those at runtime — major bumps from those
ecosystems will trigger a comment instead of an auto-merge.