### PR TITLE
ci: auto-merge github-actions[bot] changelog PRs too

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,10 +1,10 @@
-name: Dependabot auto-merge
+name: Auto-merge bot PRs
 
-# Auto-approves and enables auto-merge for dependabot PRs that bump
-# packages by patch or minor. Major bumps are surfaced for manual review
-# (dependabot.yml also already ignores semver-major for nuget/npm; this
-# workflow is the runtime safety net for docker / github-actions
-# ecosystems where major bumps still flow through).
+# Auto-approves and enables auto-merge for:
+#   1. dependabot[bot] patch/minor bumps (majors stay manual)
+#   2. github-actions[bot] changelog PRs (CHANGELOG.md-only changes)
+#
+# Major bumps from dependabot are commented and left for human review.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -14,7 +14,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  auto-merge:
+  dependabot:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
@@ -42,3 +42,38 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr comment "$PR_URL" --body "🛑 Major version bump — not auto-merged. Review the changelog before approving."
+
+  changelog:
+    # Auto-merge github-actions[bot] PRs that ONLY touch CHANGELOG.md
+    # (the automated release-changelog generation).
+    if: github.actor == 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR only modifies CHANGELOG.md
+        id: scope
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          files=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} --json files --jq '[.files[].path] | unique')
+          echo "files: $files"
+          if [ "$files" = '["CHANGELOG.md"]' ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "PR touches files other than CHANGELOG.md — skipping auto-merge."
+          fi
+
+      - name: Auto-approve changelog PR
+        if: steps.scope.outputs.ok == 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr review --approve "$PR_URL" --body "Auto-approved — CHANGELOG.md-only update from github-actions[bot]."
+
+      - name: Enable auto-merge (squash) for changelog PR
+        if: steps.scope.outputs.ok == 'true'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## What

Extends the auto-merge workflow with a second job that handles changelog PRs from `github-actions[bot]` — the release-automation that opens PRs like #343 (`docs: update changelog for 0.11.3`), #327, #315.

## How

Adds a separate `changelog` job that:

1. Triggers when `github.actor == 'github-actions[bot]'`
2. **Safety check**: verifies the PR ONLY touches `CHANGELOG.md`. Any other changed file → falls through to manual review.
3. Auto-approves and enables `gh pr merge --auto --squash`.

The existing dependabot job is untouched.

Renamed the workflow display name from `Dependabot auto-merge` → `Auto-merge bot PRs` to reflect the wider scope. File path unchanged so branch protection / Actions history stays intact.

## Effect on #343

Once this merges, the next changelog PR opened by github-actions[bot] will auto-approve + auto-merge. #343 itself was opened before this workflow exists, so it'll need a manual approve (or an empty commit to re-trigger the workflow).