### PR TITLE
fix(ci): de-flake checkout time test + make K6 perf dispatch-only

### DIFF
--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -18,8 +18,11 @@ on:
         description: 'Target gateway URL (leave empty for default)'
         required: false
         type: string
-  schedule:
-    - cron: '0 4 * * MON'  # Weekly Monday 4 AM UTC (smoke test)
+  # Run on demand only. The full-stack smoke test needs a real environment
+  # (MONGODB_URL / REDIS_URL / SQLSERVER_URL connection strings, a SQL Server
+  # container for ordering, and the discount service) that this workflow does
+  # not yet provision, so the weekly `schedule` only produced recurring red on
+  # main. Re-add the cron once the service/DB wiring below is complete.
 
 concurrency:
   group: perf-test
@@ -69,13 +72,18 @@ jobs:
         run: |
           dotnet build Ecommerce.sln --configuration Release
 
-          # Start all microservices in background
-          cd Services/Catalog/Catalog.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8001" & cd ../../..
-          cd Services/Basket/Basket.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8002" & cd ../../..
-          cd Services/Ordering/Ordering.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8004" & cd ../../..
+          # Start the microservices and gateway in background subshells. Each cd
+          # is scoped to its own subshell so it never moves the parent shell out
+          # of the repo root. The previous `cd X && dotnet run & cd ../../..`
+          # pattern ran the foreground `cd ../../..` in the parent shell, walking
+          # it above the repo, so every service after the first (and the gateway)
+          # failed with "No such file or directory" and never started.
+          ( cd Services/Catalog/Catalog.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8001" ) &
+          ( cd Services/Basket/Basket.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8002" ) &
+          ( cd Services/Ordering/Ordering.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8004" ) &
 
           # Start API Gateway
-          cd ApiGateways/Ocelot.ApiGateway && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8010" & cd ../..
+          ( cd ApiGateways/Ocelot.ApiGateway && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8010" ) &
 
           # Wait for the gateway to accept connections. Ocelot exposes no /health
           # route, so treat ANY HTTP response (even 404) as "process is listening".

--- a/micro-frontends/checkout/src/helpers/formatUtils.test.ts
+++ b/micro-frontends/checkout/src/helpers/formatUtils.test.ts
@@ -124,6 +124,20 @@ describe('formatUtils', () => {
   });
 
   describe('formatRelativeTime', () => {
+    // Freeze the clock so the timestamps built here and the `new Date()` inside
+    // formatRelativeTime resolve to the exact same instant. Otherwise the few
+    // milliseconds between the two calls push an exactly-one-day delta just past
+    // the boundary (Math.floor(-86400.001) -> -86401 -> "2 days ago"), which
+    // made these tests ~50/50 flaky depending on wall-clock timing.
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should format recent past', () => {
       const yesterday = new Date(Date.now() - 86400000); // 1 day ago
       const result = formatRelativeTime(yesterday);


### PR DESCRIPTION
Follow-up to #468. After #468 merged, the post-merge CI run on `main` went red on a **pre-existing flaky test** (not caused by #468), and a manual perf run surfaced a **pre-existing service-startup bug**.

## 1. Flaky test → main CI red

`checkout/src/helpers/formatUtils.test.ts` › `formatRelativeTime` built timestamps from `Date.now()`, but the implementation reads `new Date()` a few ms later. For an exactly-one-day delta that pushes the value just past the boundary — `Math.floor(-86400.001) = -86401` → rendered as **"2 days ago"** instead of **"yesterday"**. It only passed when both calls landed in the same millisecond (~50/50), so it passed on #468's PR run but failed the push-to-main run. The "tomorrow" and "now" cases had the same defect.

**Fix:** freeze the clock with jest fake timers in that suite → all five cases deterministic. Verified by running `checkout:test` repeatedly.

## 2. Perf workflow

A manual `workflow_dispatch` run confirmed the k6 install fix from #468 works (it now reaches service startup). Two changes here:

- **Drop the weekly `schedule`** (keep `workflow_dispatch`). The full-stack smoke test needs infra this workflow doesn't provision yet — `MONGODB_URL`/`REDIS_URL`/`SQLSERVER_URL` connection-string env vars, a **SQL Server** container for ordering (only Postgres is provided), and the discount service — so the cron only produced recurring red on `main`. Documented inline; re-add once wired.
- **Fix service startup**: each service now starts in its own background subshell. The old `cd X && dotnet run & cd ../../..` ran the foreground `cd ../../..` in the parent shell, walking it out of the repo, so only the first service ever started (`cd: ApiGateways/Ocelot.ApiGateway: No such file or directory`).

## Verification
- ✅ `checkout:test` deterministic across repeated local runs
- ⏳ This PR's CI re-confirms `frontend-quality` green on the changed project