### PR TITLE
fix(ci): re-sync nx lockfile + stop Dependabot nx churn (supersedes #474)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,19 +48,18 @@ updates:
       - "dependencies"
       - "frontend"
     groups:
-      # Keep the whole Nx toolchain on the same version. Bumping @nx/* packages
-      # individually previously left nx core and its plugins on different majors,
-      # producing an out-of-sync package-lock.json that broke `npm ci` in CI.
-      nx-monorepo:
-        patterns:
-          - "nx"
-          - "@nx/*"
-          - "@nrwl/*"
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
     ignore:
+      # nx must be upgraded as a coordinated set via `nx migrate`, not piecemeal.
+      # Individual @nx/* bumps leave nx core and its plugins on mismatched versions
+      # and generate a lockfile that `npm ci` rejects (missing nested @nx/*@NN
+      # transitive deps), which repeatedly broke the frontend CI (see #468 / #474).
+      - dependency-name: "nx"
+      - dependency-name: "@nx/*"
+      - dependency-name: "@nrwl/*"
       # Ignore major version updates for stability
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -85,19 +84,18 @@ updates:
       - "frontend"
       - "micro-frontend"
     groups:
-      # Keep the whole Nx toolchain on the same version. Bumping @nx/* packages
-      # individually previously left nx core and its plugins on different majors,
-      # producing an out-of-sync package-lock.json that broke `npm ci` in CI.
-      nx-monorepo:
-        patterns:
-          - "nx"
-          - "@nx/*"
-          - "@nrwl/*"
       minor-and-patch:
         update-types:
           - "minor"
           - "patch"
     ignore:
+      # nx must be upgraded as a coordinated set via `nx migrate`, not piecemeal.
+      # Individual @nx/* bumps leave nx core and its plugins on mismatched versions
+      # and generate a lockfile that `npm ci` rejects (missing nested @nx/*@NN
+      # transitive deps), which repeatedly broke the frontend CI (see #468 / #474).
+      - dependency-name: "nx"
+      - dependency-name: "@nx/*"
+      - dependency-name: "@nrwl/*"
       # Ignore major version updates for stability
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -18,8 +18,11 @@ on:
         description: 'Target gateway URL (leave empty for default)'
         required: false
         type: string
-  schedule:
-    - cron: '0 4 * * MON'  # Weekly Monday 4 AM UTC (smoke test)
+  # Run on demand only. The full-stack smoke test needs a real environment
+  # (MONGODB_URL / REDIS_URL / SQLSERVER_URL connection strings, a SQL Server
+  # container for ordering, and the discount service) that this workflow does
+  # not yet provision, so the weekly `schedule` only produced recurring red on
+  # main. Re-add the cron once the service/DB wiring below is complete.
 
 concurrency:
   group: perf-test
@@ -69,13 +72,18 @@ jobs:
         run: |
           dotnet build Ecommerce.sln --configuration Release
 
-          # Start all microservices in background
-          cd Services/Catalog/Catalog.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8001" & cd ../../..
-          cd Services/Basket/Basket.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8002" & cd ../../..
-          cd Services/Ordering/Ordering.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8004" & cd ../../..
+          # Start the microservices and gateway in background subshells. Each cd
+          # is scoped to its own subshell so it never moves the parent shell out
+          # of the repo root. The previous `cd X && dotnet run & cd ../../..`
+          # pattern ran the foreground `cd ../../..` in the parent shell, walking
+          # it above the repo, so every service after the first (and the gateway)
+          # failed with "No such file or directory" and never started.
+          ( cd Services/Catalog/Catalog.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8001" ) &
+          ( cd Services/Basket/Basket.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8002" ) &
+          ( cd Services/Ordering/Ordering.API && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8004" ) &
 
           # Start API Gateway
-          cd ApiGateways/Ocelot.ApiGateway && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8010" & cd ../..
+          ( cd ApiGateways/Ocelot.ApiGateway && dotnet run --configuration Release --no-build --urls "http://0.0.0.0:8010" ) &
 
           # Wait for the gateway to accept connections. Ocelot exposes no /health
           # route, so treat ANY HTTP response (even 404) as "process is listening".

--- a/micro-frontends/checkout/src/helpers/formatUtils.test.ts
+++ b/micro-frontends/checkout/src/helpers/formatUtils.test.ts
@@ -124,6 +124,20 @@ describe('formatUtils', () => {
   });
 
   describe('formatRelativeTime', () => {
+    // Freeze the clock so the timestamps built here and the `new Date()` inside
+    // formatRelativeTime resolve to the exact same instant. Otherwise the few
+    // milliseconds between the two calls push an exactly-one-day delta just past
+    // the boundary (Math.floor(-86400.001) -> -86401 -> "2 days ago"), which
+    // made these tests ~50/50 flaky depending on wall-clock timing.
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2024-06-15T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('should format recent past', () => {
       const yesterday = new Date(Date.now() - 86400000); // 1 day ago
       const result = formatRelativeTime(yesterday);

--- a/micro-frontends/package-lock.json
+++ b/micro-frontends/package-lock.json
@@ -4906,6 +4906,77 @@
         "nx": ">= 21 <= 23 || ^22.0.0-0"
       }
     },
+    "node_modules/@nx/module-federation/node_modules/@nx/eslint": {
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-22.7.6.tgz",
+      "integrity": "sha512-KWK6qUfKUgnPhdePZSQYy6CSef55/Fo0ykhkFw1P9fLzI9NogEAjObRdrZ5TkUQweTy4JzKZsSxIhYtphGsxRA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@nx/devkit": "22.7.6",
+        "@nx/js": "22.7.6",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0",
+        "typescript": "~5.9.2"
+      },
+      "peerDependencies": {
+        "@nx/jest": "22.7.6",
+        "@zkochan/js-yaml": "0.0.7",
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nx/jest": {
+          "optional": true
+        },
+        "@zkochan/js-yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/jest": {
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-22.7.6.tgz",
+      "integrity": "sha512-VgkMDTHKosQN15r0u08ujWIXVvQk9Z1Y/+JqWeWy0v+s21ju9RHhEgARHHXAyV3N5XmVfQ77rHkLIzev4vqpOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jest/reporters": "^30.0.2",
+        "@jest/test-result": "^30.0.2",
+        "@nx/devkit": "22.7.6",
+        "@nx/js": "22.7.6",
+        "@phenomnomnominal/tsquery": "~6.2.0",
+        "identity-obj-proxy": "3.0.0",
+        "jest-config": "^30.0.2",
+        "jest-resolve": "^30.0.2",
+        "jest-util": "^30.0.2",
+        "minimatch": "10.2.5",
+        "picocolors": "^1.1.0",
+        "resolve.exports": "2.0.3",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0",
+        "yargs-parser": "21.1.1"
+      }
+    },
+    "node_modules/@nx/module-federation/node_modules/@nx/jest/node_modules/@phenomnomnominal/tsquery": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-6.2.0.tgz",
+      "integrity": "sha512-Vo9nkhfZxDB/sBiqIY3pjDC4mOSyure+AFlEW5hcy/tRE82MqCXjRN4InnVNMldinRt0dLYqg4HAU2XPq5e1LA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/esquery": "^1.5.4",
+        "esquery": "^1.7.0"
+      },
+      "peerDependencies": {
+        "typescript": ">3.0.0"
+      }
+    },
     "node_modules/@nx/module-federation/node_modules/@nx/js": {
       "version": "22.7.6",
       "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.6.tgz",
@@ -5013,9 +5084,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5030,9 +5098,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5047,9 +5112,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5064,9 +5126,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6005,6 +6064,48 @@
         }
       }
     },
+    "node_modules/@nx/playwright/node_modules/@nx/jest": {
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-22.7.6.tgz",
+      "integrity": "sha512-VgkMDTHKosQN15r0u08ujWIXVvQk9Z1Y/+JqWeWy0v+s21ju9RHhEgARHHXAyV3N5XmVfQ77rHkLIzev4vqpOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jest/reporters": "^30.0.2",
+        "@jest/test-result": "^30.0.2",
+        "@nx/devkit": "22.7.6",
+        "@nx/js": "22.7.6",
+        "@phenomnomnominal/tsquery": "~6.2.0",
+        "identity-obj-proxy": "3.0.0",
+        "jest-config": "^30.0.2",
+        "jest-resolve": "^30.0.2",
+        "jest-util": "^30.0.2",
+        "minimatch": "10.2.5",
+        "picocolors": "^1.1.0",
+        "resolve.exports": "2.0.3",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0",
+        "yargs-parser": "21.1.1"
+      }
+    },
+    "node_modules/@nx/playwright/node_modules/@nx/jest/node_modules/@phenomnomnominal/tsquery": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-6.2.0.tgz",
+      "integrity": "sha512-Vo9nkhfZxDB/sBiqIY3pjDC4mOSyure+AFlEW5hcy/tRE82MqCXjRN4InnVNMldinRt0dLYqg4HAU2XPq5e1LA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/esquery": "^1.5.4",
+        "esquery": "^1.7.0"
+      },
+      "peerDependencies": {
+        "typescript": ">3.0.0"
+      }
+    },
     "node_modules/@nx/playwright/node_modules/@nx/js": {
       "version": "22.7.6",
       "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.6.tgz",
@@ -6112,9 +6213,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6129,9 +6227,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6146,9 +6241,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6163,9 +6255,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6731,6 +6820,32 @@
         }
       }
     },
+    "node_modules/@nx/react/node_modules/@nx/jest": {
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-22.7.6.tgz",
+      "integrity": "sha512-VgkMDTHKosQN15r0u08ujWIXVvQk9Z1Y/+JqWeWy0v+s21ju9RHhEgARHHXAyV3N5XmVfQ77rHkLIzev4vqpOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jest/reporters": "^30.0.2",
+        "@jest/test-result": "^30.0.2",
+        "@nx/devkit": "22.7.6",
+        "@nx/js": "22.7.6",
+        "@phenomnomnominal/tsquery": "~6.2.0",
+        "identity-obj-proxy": "3.0.0",
+        "jest-config": "^30.0.2",
+        "jest-resolve": "^30.0.2",
+        "jest-util": "^30.0.2",
+        "minimatch": "10.2.5",
+        "picocolors": "^1.1.0",
+        "resolve.exports": "2.0.3",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0",
+        "yargs-parser": "21.1.1"
+      }
+    },
     "node_modules/@nx/react/node_modules/@nx/js": {
       "version": "22.7.6",
       "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.6.tgz",
@@ -6838,9 +6953,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6855,9 +6967,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6872,9 +6981,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6889,9 +6995,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7594,9 +7697,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7611,9 +7711,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7628,9 +7725,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7645,9 +7739,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8189,6 +8280,61 @@
         "nx": ">= 21 <= 23 || ^22.0.0-0"
       }
     },
+    "node_modules/@nx/vite/node_modules/@nx/eslint": {
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-22.7.6.tgz",
+      "integrity": "sha512-KWK6qUfKUgnPhdePZSQYy6CSef55/Fo0ykhkFw1P9fLzI9NogEAjObRdrZ5TkUQweTy4JzKZsSxIhYtphGsxRA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@nx/devkit": "22.7.6",
+        "@nx/js": "22.7.6",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0",
+        "typescript": "~5.9.2"
+      },
+      "peerDependencies": {
+        "@nx/jest": "22.7.6",
+        "@zkochan/js-yaml": "0.0.7",
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@nx/jest": {
+          "optional": true
+        },
+        "@zkochan/js-yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nx/vite/node_modules/@nx/jest": {
+      "version": "22.7.6",
+      "resolved": "https://registry.npmjs.org/@nx/jest/-/jest-22.7.6.tgz",
+      "integrity": "sha512-VgkMDTHKosQN15r0u08ujWIXVvQk9Z1Y/+JqWeWy0v+s21ju9RHhEgARHHXAyV3N5XmVfQ77rHkLIzev4vqpOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jest/reporters": "^30.0.2",
+        "@jest/test-result": "^30.0.2",
+        "@nx/devkit": "22.7.6",
+        "@nx/js": "22.7.6",
+        "@phenomnomnominal/tsquery": "~6.2.0",
+        "identity-obj-proxy": "3.0.0",
+        "jest-config": "^30.0.2",
+        "jest-resolve": "^30.0.2",
+        "jest-util": "^30.0.2",
+        "minimatch": "10.2.5",
+        "picocolors": "^1.1.0",
+        "resolve.exports": "2.0.3",
+        "semver": "^7.6.3",
+        "tslib": "^2.3.0",
+        "yargs-parser": "21.1.1"
+      }
+    },
     "node_modules/@nx/vite/node_modules/@nx/js": {
       "version": "22.7.6",
       "resolved": "https://registry.npmjs.org/@nx/js/-/js-22.7.6.tgz",
@@ -8297,9 +8443,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8314,9 +8457,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8331,9 +8471,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8348,9 +8485,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9098,9 +9232,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9115,9 +9246,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9132,9 +9260,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9149,9 +9274,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11293,9 +11415,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11310,9 +11429,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11327,9 +11443,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11344,9 +11457,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11361,9 +11471,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11378,9 +11485,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11395,9 +11499,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11412,9 +11513,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11429,9 +11527,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11446,9 +11541,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11463,9 +11555,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11480,9 +11569,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11497,9 +11583,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12416,9 +12499,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12436,9 +12516,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12456,9 +12533,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12476,9 +12550,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12496,9 +12567,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -12516,9 +12584,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -18293,7 +18358,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.2"
@@ -21013,7 +21078,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -28014,7 +28079,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sass": {


### PR DESCRIPTION
Consolidates #474 and fixes a **fresh main breakage**. After #468 merged, the new Dependabot grouping produced grouped PRs (good — #469/#471/#472 instead of dozens of singletons), but **#471 auto-merged a grouped bump that moved `@nx/*` to 22.7.6 with a lockfile missing their nested `@nx/*@22.7.6` deps**, re-breaking `npm ci` on main — the same class of failure #468 fixed at 22.7.5.

## Root cause (why it kept recurring)

nx packages are split across majors (`nx` core + half the plugins pinned at 21.6.11; `@nx/react`/`webpack`/`module-federation`/`playwright` floating at ^22). nx is designed to be upgraded as a **coordinated set via `nx migrate`**, not piecemeal — so every individual `@nx/*` patch bump (e.g. 22.7.5→22.7.6, which is *inside* the `^22` range and so escapes the semver-major ignore) regenerates a lockfile that `npm ci` rejects. Lock-only fixes get re-broken on the next nx bump.

## Changes

1. **`micro-frontends/package-lock.json`** — regenerated with npm 10.9.2 so it's back in sync. Verified: real `npm ci` passes; `nx lint`/`test`/`build` green for all 5 projects. (Versions left as-is — the mixed-major state builds fine; unifying is optional cleanup via `nx migrate` later.)
2. **`.github/dependabot.yml`** — ignore `nx`, `@nx/*`, `@nrwl/*` in both npm ecosystems so Dependabot stops bumping them piecemeal. The `nx-monorepo` group didn't hold (#471 swept nx into `minor-and-patch`), so `ignore` replaces it as the guard; the `minor-and-patch` group stays for everything else.
3. **`checkout/formatUtils.test.ts`** — freeze the clock in the `formatRelativeTime` suite (carried from #474). The day-boundary tests were ~50/50 flaky and failed the post-#468 push-to-main CI.
4. **`performance-test.yml`** — dispatch-only (drop the weekly cron that only produced red) + background-subshell service startup fix (carried from #474).

## Verification
- ✅ real `npm ci` (npm 10.9.2) passes on the regenerated lock
- ✅ `nx run-many lint/test/build --all` → all 5 projects green
- ✅ `checkout:test` deterministic across repeated runs

## Follow-ups (flagged, not in this PR)
- Auto-merge merges any PR because **no status check is required** — ignoring nx removes the only demonstrated breakage source, but making `frontend-quality` a required check would be the general guard (needs care: it interacts with the path-filtered skipped jobs).
- Optionally unify nx via `nx migrate nx@latest` to drop the mixed-major state.
- Wire the perf workflow's DB env (SQL Server container, `MONGODB_URL`/`REDIS_URL`/`SQLSERVER_URL`, discount service) to restore a scheduled smoke test.